### PR TITLE
feat: add hook/useVModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Currently supported functions:
   - [`useQueue`](https://vueposu.netlify.app/state/useQueue.html)
   - [`useSet`](https://vueposu.netlify.app/state/useSet.html)
   - [`useToggle`](https://vueposu.netlify.app/state/useToggle.html)
+  - [`useVModel`](https://vueposu.netlify.app/state/useVModel.html)
 
 - SWR
 
@@ -145,7 +146,6 @@ Currently supported functions:
   - [`useInterval`](https://vueposu.netlify.app/animation/useInterval.html)
   <!-- - [`useRaf`](https://vueposu.netlify.app/animation/useRaf.html) -->
   - [`useTimeout`](https://vueposu.netlify.app/animation/useTimeout.html)
-
 
 <br />
 

--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -13,10 +13,11 @@ export function useVModel<P extends object>(
   emit?: (name: string, value: any) => void,
 ) {
   let _emit = emit;
+  const instance = getCurrentInstance();
   if (!emit && isVue3) {
-    _emit = getCurrentInstance()?.emit;
+    _emit = instance?.emit;
   } else {
-    emit = (getCurrentInstance() as any)?.$emit;
+    emit = (instance as any)?.$emit.bind(instance);
   }
   return computed({
     get() {

--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -1,0 +1,29 @@
+import { computed, getCurrentInstance, isVue3 } from 'vue-demi';
+
+/**
+ * Shorthand for v-model binding, props + emit -> ref
+ * inspired by antfu vueuse: https://github.com/antfu/vueuse/blob/master/packages/core/useVModel/index.ts
+ * @param props
+ * @param key
+ * @param emit
+ */
+export function useVModel<P extends object>(
+  props: P,
+  key: keyof P,
+  emit?: (name: string, value: any) => void,
+) {
+  let _emit = emit;
+  if (!emit && isVue3) {
+    _emit = getCurrentInstance()?.emit;
+  } else {
+    emit = (getCurrentInstance() as any)?.$emit;
+  }
+  return computed({
+    get() {
+      return props[key];
+    },
+    set(value) {
+      _emit(`update:${key}`, value);
+    },
+  });
+}

--- a/test/unit/hooks/useVModel.spec.ts
+++ b/test/unit/hooks/useVModel.spec.ts
@@ -21,8 +21,8 @@ describe('hooks/useVModel', () => {
       props: {
         modelValue: Boolean,
       },
-      setup(props, { emit }) {
-        const checked = useVModel(props, 'modelValue', emit);
+      setup(props) {
+        const checked = useVModel(props, 'modelValue');
         const update = event => {
           const checkbox = event.target as HTMLInputElement;
           checked.value = checkbox.checked;

--- a/test/unit/hooks/useVModel.spec.ts
+++ b/test/unit/hooks/useVModel.spec.ts
@@ -1,0 +1,51 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent, ref } from 'vue';
+import { useVModel } from '../../../src/hooks/useVModel';
+import { wait } from '../../utils/helper';
+
+// TODO: need more test case
+describe('hooks/useVModel', () => {
+  it('official demo should work', async () => {
+    // @see demo: https://vuejs.org/v2/guide/components-custom-events.html
+    const BaseCheckbox = defineComponent({
+      template: `
+        <input
+        type="checkbox"
+        v-bind:checked="checked"
+        v-on:change="update">
+      `,
+      model: {
+        prop: 'modelValue',
+        event: 'change',
+      },
+      props: {
+        modelValue: Boolean,
+      },
+      setup(props, { emit }) {
+        const checked = useVModel(props, 'modelValue', emit);
+        const update = event => {
+          const checkbox = event.target as HTMLInputElement;
+          checked.value = checkbox.checked;
+          console.log(checked.value, checkbox.checked);
+        };
+        return { checked, update };
+      },
+    });
+
+    const component = mount(
+      defineComponent({
+        components: { BaseCheckbox },
+        template: `<BaseCheckbox v-model="checked" />`,
+        setup() {
+          const checked = ref(false);
+          return { checked };
+        },
+      }),
+    );
+
+    expect(component.vm.checked).toBe(false);
+    component.find('input').trigger('click');
+    await wait();
+    expect(component.vm.checked).toBe(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,9 +5712,9 @@ verror@1.10.0:
     extsprintf "^1.2.0"
 
 vue-demi@latest:
-  version "0.3.3"
-  resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.3.3.tgz#27d7ae33e1d82752418ecfded60e625c5cc81866"
-  integrity sha512-/CvXJUp7e41C/jS5ZgflMQgkY2qFX1ZkZq1kYwYH5RCC9gGy1vgvjsldtQlVORaAUt55+k/mQIUnUKNrLosoIw==
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.4.5.tgz#ea422a4468cb6321a746826a368a770607f87791"
+  integrity sha512-51xf1B6hV2PfjnzYHO/yUForFCRQ49KS8ngQb5T6l1HDEmfghTFtsxtRa5tbx4eqQsH76ll/0gIxuf1gei0ubw==
 
 vue@^3:
   version "3.0.0"


### PR DESCRIPTION
Usage in vue3 will look like that, is there a better way to write ?

![code-snapshot](https://user-images.githubusercontent.com/12481935/102174581-c8f09480-3ed8-11eb-93ba-f3c5f1073bd7.png)

**Now have some issuses**

## How to mock real vue2.x env in our project [help wanted] ?

What is a good way ?

## If ignore emit parameter will throw a warning

![image](https://user-images.githubusercontent.com/12481935/102174966-8bd8d200-3ed9-11eb-874b-449c20ac3610.png)

we need to fix that .

## Dependency upgrade

upgrade vue-demi@0.3.3 -> vue-demo@0.4.5 in yarn.lock, because, vue-demi add new constant - `isVue3`.

# Related link

vue doc: https://v3.vuejs.org/guide/migration/v-model.html#overview
antfu vueuse: https://github.com/antfu/vueuse/blob/master/packages/core/useVModel/index.ts

@glitchboyl CC